### PR TITLE
Update conf ft detection fallback

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -196,6 +196,9 @@ function M.conf(path, bufnr)
   if vim.fn.did_filetype() ~= 0 or path:find(vim.g.ft_ignore_pat) then
     return
   end
+  if path:find('%.conf$') then
+    return 'conf'
+  end
   for _, line in ipairs(getlines(bufnr, 1, 5)) do
     if line:find('^#') then
       return 'conf'


### PR DESCRIPTION
Currently ft detection for *.conf files doesn't work if we create a new .conf file or if we open .conf file without comments. This patch fixes that.